### PR TITLE
Add a script to automatically generate the snippet files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+modularize

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
-#Lodash modules snippets
+# Lodash modules snippets
 
 ### 0.2
 - `isFinite` now will imported as `_isFinite` (not override the native `isFinite` function)
 - `isNaN` now will imported as `_isNaN` (not override the native `isNaN` function)
+
+### 0.1
+- Initial release

--- a/README.md
+++ b/README.md
@@ -4,10 +4,12 @@ Import easily only the modules you need from [lodash](https://lodash.com/).
 Supports [lodash 3.3.0v](https://lodash.com/).
 
 ##Examples
+
 - CommonJS: typing `r_map` will resolve to `var map = require('lodash/collection/map');`
 - ES2015: typing `i_map` will resolve to `import map from 'lodash/collection/map';`
 
 ##Installation
+
 The recomand way is by using [Package Control](https://packagecontrol.io/):
 - open the command palette by typing `⌘+shift+p` on OS X or `ctrl+shift+p` on Windows/Linux
 - select `Package Control: Install Package`
@@ -17,3 +19,12 @@ The recomand way is by using [Package Control](https://packagecontrol.io/):
 The other way is:
 - open the terminal on sublime's packages folder
 - type `git clone https://github.com/oriSomething/lodash-modules-sublime.git`
+
+## Contributing
+
+It seems like the best way to get a list of lodash's methods and collections
+is by using `lodash-cli`, make sure you have [npm][npm] installed, then run
+`npm install` in this directory.
+
+That'll install `lodash-cli`; then you just need to run `./build-snippets.sh`
+to update the snippets.

--- a/README.md
+++ b/README.md
@@ -1,24 +1,28 @@
-#Lodash modules snippets (for sublime text)
+# Lodash modules snippets (for sublime text)
 
 Import easily only the modules you need from [lodash](https://lodash.com/).
 Supports [lodash 3.3.0v](https://lodash.com/).
 
-##Examples
+## Examples
 
 - CommonJS: typing `r_map` will resolve to `var map = require('lodash/collection/map');`
 - ES2015: typing `i_map` will resolve to `import map from 'lodash/collection/map';`
 
-##Installation
+
+## Installation
 
 The recomand way is by using [Package Control](https://packagecontrol.io/):
-- open the command palette by typing `⌘+shift+p` on OS X or `ctrl+shift+p` on Windows/Linux
-- select `Package Control: Install Package`
-- type `Lodash modules snippets`
+
+1. open the command palette by typing `⌘+shift+p` on OS X or `ctrl+shift+p` on Windows/Linux
+2. select `Package Control: Install Package`
+3. type `Lodash modules snippets`
 
 
 The other way is:
-- open the terminal on sublime's packages folder
-- type `git clone https://github.com/oriSomething/lodash-modules-sublime.git`
+
+1. open the terminal on sublime's packages folder
+2. type `git clone https://github.com/oriSomething/lodash-modules-sublime.git`
+
 
 ## Contributing
 

--- a/build-snippets.sh
+++ b/build-snippets.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# helper function
+function contains() {
+	# from http://stackoverflow.com/questions/3685970/check-if-an-array-contains-a-value
+	local n=$#
+	local value=${!n}
+	for ((i=1;i < $#;i++)) {
+		if [ "${!i}" == "${value}" ]; then
+			echo "y"
+			return 0
+		fi
+	}
+	echo "n"
+	return 1
+}
+
+# prepare the filename template
+filename='snippets/lodash-@type-modules-@kebabPath.sublime-snippet'
+
+# prepare the list of native methods
+native=("isFinite" "isNaN")
+
+# use lodash-cli to build the list of methods
+./node_modules/.bin/lodash modularize
+
+# remove the files that we don't care about
+rm -f modularize/*.js
+rm -rf modularize/internal
+
+# read in the snippets
+esSnippet=$(cat './snippet-es.xml')
+cjsSnippet=$(cat './snippet-cjs.xml')
+
+# and let 'er rip!
+for path in modularize/**/*.js; do
+	# remove the .js from the filename
+	path=$(echo "$path" | cut -d'.' -f1)
+
+	# 'path' looks like 'modularize/array/chunk'
+	# the 'collection' is the second folder name -- field 2
+	collection=$(echo "$path" | cut -d'/' -f2)
+	# the 'method' is the third folder name -- field 3
+	method=$(echo "$path" | cut -d'/' -f3)
+
+	# if the method is in the array of native functions, then put an
+	# underscore in front of it.
+	safeMethod=$method
+	if [ "$(contains "${native[@]}" "$method")" == "y" ]; then
+		safeMethod="_$method"
+	fi
+
+	# compute the destination filename
+	dest=$(echo $filename | sed s/'@kebabPath'/"$collection-$method"/)
+
+	# output the commonjs snippet for this method
+	commonjsDest=$(echo "$dest" | sed s/'@type'/"cjs"/)
+	echo "$cjsSnippet" \
+		| sed s/'@var'/"$safeMethod"/g \
+		| sed s/'@method'/"$method"/g \
+		| sed s/'@collection'/"$collection"/g \
+		> "$commonjsDest"
+
+	# output the es2015 snippet for this method
+	esDest=$(echo "$dest" | sed s/'@type'/"es"/)
+	echo "$esSnippet" \
+		| sed s/'@var'/"$safeMethod"/g \
+		| sed s/'@method'/"$method"/g \
+		| sed s/'@collection'/"$collection"/g \
+		> "$esDest"
+done

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "author": "Ori Livni (@oriSomething)",
   "license": "MIT",
   "repository": "https://github.com/oriSomething/lodash-modules-sublime.git",
+  "dependencies": {
+    "lodash-cli": "^3.10.1"
+  },
   "keywords": [
     "sublime",
     "text",

--- a/snippet-cjs.xml
+++ b/snippet-cjs.xml
@@ -1,0 +1,8 @@
+<snippet>
+  <content><![CDATA[
+var @var = require('lodash/@collection/@method');
+]]></content>
+  <tabTrigger>r_@method</tabTrigger>
+  <scope>source.js</scope>
+  <description>CJS lodash/@collection/@method</description>
+</snippet>

--- a/snippet-es.xml
+++ b/snippet-es.xml
@@ -1,0 +1,8 @@
+<snippet>
+  <content><![CDATA[
+import @var from 'lodash/@collection/@method';
+]]></content>
+  <tabTrigger>i_@method</tabTrigger>
+  <scope>source.js</scope>
+  <description>ES lodash/@collection/@method</description>
+</snippet>


### PR DESCRIPTION
I used this to generate the snippet updates in #1.

It uses `npm` to install `lodash-cli`, because I couldn't figure out a simpler way to gather lodash's collections and functions, then runs a bash script to generate the snippet files.

I love this package. Thank you for making it.
